### PR TITLE
mb_strlen for multibyte check

### DIFF
--- a/src/voku/helper/UTF8.php
+++ b/src/voku/helper/UTF8.php
@@ -6672,7 +6672,8 @@ final class UTF8
       return $str;
     }
 
-    $max = strlen($str);
+    $max = mb_strlen($str, '8bit');
+    
     $buf = '';
 
     /** @noinspection ForeachInvariantsInspection */


### PR DESCRIPTION
**Fixes** #

#### Proposed Changes
* use mb_strlen with specific encoding '8bit' to avoid problems when using mbstring.func_overload in php.ini
